### PR TITLE
Highlight uppercase identifiers, '@' and '$'

### DIFF
--- a/syntaxes/pestfile.tmLanguage.json
+++ b/syntaxes/pestfile.tmLanguage.json
@@ -65,11 +65,11 @@
 				},
 				{
 					"name": "variable.name.pestfile",
-					"match": "[a-z_][a-z0-9_]*"
+					"match": "[A-Za-z_][A-Za-z0-9_]*"
 				},
 				{
 					"name": "keyword.operator.pestfile",
-					"match": "\\+|-|\\.\\.|!|~|_"
+					"match": "\\+|-|\\.\\.|!|~|_|@|$"
 				}
 			]
 		},


### PR DESCRIPTION
Capital letters are valid identifiers in pest rules (at least they work for me! It might go against conventions I'm unaware of).

@ and $ are used by pest to denote [atomic rules](https://pest.rs/book/grammars/syntax.html?highlight=comment#silent-and-atomic-rules).