### PR TITLE
fix nested comments, highlight {m, n} repetitions

### DIFF
--- a/syntaxes/pestfile.tmLanguage.json
+++ b/syntaxes/pestfile.tmLanguage.json
@@ -72,7 +72,7 @@
                 },
                 {
                     "name": "keyword.operator.repetition.pestfile",
-                    "match": "\\+|\\*|\\?|{\\s*[0-9]*\\s*,\\s*[0-9]*\\s*}"
+                    "match": "\\+|\\*|\\?|{\\s*[0-9]+\\s*,\\s*}|{\\s*,\\s*[0-9]+\\s*}|{\\s*[0-9]+\\s*,\\s*[0-9]+\\s*}"
                 },
                 {
                     "name": "variable.name.pestfile",
@@ -120,7 +120,11 @@
                     "name": "comment.block.pestfile",
                     "begin": "/\\*",
                     "end": "\\*/",
-                    "patterns": [{ "include": "#multilinecomments" }]
+                    "patterns": [
+                        {
+                            "include": "#multilinecomments"
+                        }
+                    ]
                 }
             ]
         }

--- a/syntaxes/pestfile.tmLanguage.json
+++ b/syntaxes/pestfile.tmLanguage.json
@@ -10,6 +10,9 @@
         },
         {
             "include": "#comments"
+        },
+        {
+            "include": "#multilinecomments"
         }
     ],
     "repository": {
@@ -65,7 +68,11 @@
                 },
                 {
                     "name": "keyword.operator.pestfile",
-                    "match": "\\+|-|\\.\\.|!|~|_|@|\\$|\\*|\\?"
+                    "match": "-|\\.\\.|!|~|_|@|\\$"
+                },
+                {
+                    "name": "keyword.operator.repetition.pestfile",
+                    "match": "\\+|\\*|\\?|{\\s*[0-9]*\\s*,\\s*[0-9]*\\s*}"
                 },
                 {
                     "name": "variable.name.pestfile",
@@ -104,12 +111,16 @@
                 {
                     "name": "comment.line.pestfile",
                     "match": "//.*"
-                },
+                }
+            ]
+        },
+        "multilinecomments": {
+            "patterns": [
                 {
                     "name": "comment.block.pestfile",
                     "begin": "/\\*",
                     "end": "\\*/",
-                    "patterns": [{ "include": "#comments" }]
+                    "patterns": [{ "include": "#multilinecomments" }]
                 }
             ]
         }


### PR DESCRIPTION
Fixes #3 :tada:
By {m,n} repetitions I mean other **numbers of repetitions** as seen on here: https://pest.rs/book/grammars/syntax.html#repetition

I've tested that it handles optional spacing and numbers so it should work for all of these:
```
foo {1, 2}
foo {3,}
foo {  , 4 }
foo { 5 ,    6  }
```
I also managed to not highlight this since it isn't valid. Not entirely convinced that it's worth the complication, I could go either way
```
foo {,} 
```