### PR TITLE
match pest files using fileTypes

### DIFF
--- a/syntaxes/pestfile.tmLanguage.json
+++ b/syntaxes/pestfile.tmLanguage.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
     "name": "pestfile",
+    "fileTypes": ["pest"],
     "patterns": [
         {
             "include": "#keywords"


### PR DESCRIPTION
hi!  I'm trying to use this grammar in my [text editor](https://github.com/asottile/babi) and `fileTypes` is the standard way to match grammars to filenames in textmate syntax -- I've added `pest` so it can match pest files there